### PR TITLE
monkey-patch coreadm to prevent invalid patterns

### DIFF
--- a/exercises/generate_core_when_an_app_crashes/monkey_patch_core_adm.sh
+++ b/exercises/generate_core_when_an_app_crashes/monkey_patch_core_adm.sh
@@ -1,0 +1,40 @@
+# This script is used to "monkey-patch" the coreadm util
+# that needs to be used by students to change code dumps generation
+# configuration to pass this exercise.
+# It prevents students from setting an unsupported global pattern
+# that would further lead to coreadm being unusable.
+# It is a workaround for the following issue:
+# http://smartos.org/bugview/OS-3042
+
+CORE_ADM_BIN=`which coreadm`
+
+is_core_adm_pattern_option () {
+  if [ "$1" == "-g" ]; then return 1; fi
+  if [ "$1" == "-i" ]; then return 1; fi
+
+  return 0;
+}
+
+core_adm () {
+  typeset CHECK_NEXT_PARAM=0
+  for param in $@; do
+
+    if [[ ${CHECK_NEXT_PARAM} -eq 1 ]]; then
+       case ${param} in
+         /*) true;;
+         *) (echo "coreadm: ERELPATH" 1>&2); return 1;;
+       esac
+    fi
+
+    $(is_core_adm_pattern_option ${param})
+    if [[ $? -eq 1 ]]; then
+      CHECK_NEXT_PARAM=1
+    else
+      CHECK_NEXT_PARAM=0
+    fi;
+  done
+
+  ${CORE_ADM_BIN} $@
+}
+
+alias coreadm=core_adm

--- a/lib/workshopper-exercise/executeshellscript.js
+++ b/lib/workshopper-exercise/executeshellscript.js
@@ -24,7 +24,12 @@ var fs   = require('fs');
 var async = require('async');
 var debug = require('debug')('debug-school');
 
-function executeshellscript (exercise, preCommands, postCommands, checkCallback) {
+function executeshellscript (exercise, options, checkCallback) {
+
+  if (typeof options === 'function') {
+    checkCallback = options;
+    options = null;
+  }
 
   function processor (mode, callback) {
     var submission = this.args[0]
@@ -33,20 +38,37 @@ function executeshellscript (exercise, preCommands, postCommands, checkCallback)
       checkCallback(err, stdout, stderr, callback);
     }
 
-    fs.readFile(submission, function (err, data) {
-      if (err) {
-        return callback(err);
-      } else {
+    var tasks = {};
+
+    if (options.preScript) {
+      tasks.preScript = fs.readFile.bind(global, options.preScript);
+    }
+
+    tasks.submission = fs.readFile.bind(global, submission);
+
+    async.parallel(tasks, function allScriptsRead(err, results) {
+      if (!err) {
         var scriptContent = '';
-        if (data) {
-          scriptContent = data.toString();
+
+        if (results.preScript) {
+          scriptContent += '\n' + results.preScript.toString();
         }
-        scriptContent = preCommands.join(';') + ';' + scriptContent;
-        scriptContent += postCommands.join(';');
+
+        if (options.preCommands) {
+          scriptContent += '\n' + options.preCommands.join(';')
+        }
+
+        scriptContent += '\n' + results.submission.toString();
+
+        if (options.postCommands) {
+          scriptContent += '\n' + options.postCommands.join(';');
+        }
 
         debug('Executing script:');
         debug(scriptContent);
         exec(scriptContent, checkSubmission);
+      } else {
+        return callback(err);
       }
     });
   }


### PR DESCRIPTION
Work around the following coreadm bug: http://smartos.org/bugview/OS-3042
by monkey-patching coreadm so that when students set a global pattern with
a relative path, coreadm fails.

A hint is displayed that tells students not to pass patterns representing
relative paths when setting a global core file pattern.
A

Fixes #9
