### PR TITLE
Fix incorrect solution check and add clarity to incorrect solution output. 

### DIFF
--- a/exercises/generate_core_when_an_app_crashes/exercise.js
+++ b/exercises/generate_core_when_an_app_crashes/exercise.js
@@ -130,7 +130,8 @@ function showHints(outputLines, stdErrLines, callback) {
   if (!outputLines || outputLines.length !== nbExpectedOutputLines) {
     msg = "* It seems that your script doesn't follow the instructions " +
           "regarding its output format, please read the instructions " +
-          "carefully again.";
+          "carefully again. Remember, your Node.js application should only output " +
+          "its process ID to standard output.";
     console.log(chalk.blue(msg));
   }
 

--- a/exercises/generate_core_when_an_app_crashes/problem.md
+++ b/exercises/generate_core_when_an_app_crashes/problem.md
@@ -14,7 +14,7 @@ core.pid
 ```
 where `pid` is the id of the node process that aborted.
 
-The Node.js application should only output its process ID to the standard
+The Node.js application __should only output its process ID__ to the standard
 output.
 
 To verify your solution, run the following command line:
@@ -41,5 +41,3 @@ prevent it from generating core files.__
 
 2) Pass the `--abort-on-uncaught-exception` command line switch to the `node`
 program when starting your application.
-
-

--- a/exercises/print_all_objects_with_a_given_type/exercise.js
+++ b/exercises/print_all_objects_with_a_given_type/exercise.js
@@ -46,7 +46,7 @@ exercise.addPrepare(function(callback) {
 exercise.addCleanup(cleanupCoreFiles);
 
 exercise.additionalVariables = {};
-exercise.submissionName = 'max-value';
+exercise.submissionName = 'min-value';
 
 exercise = cmdargscheck(exercise, function(args, callback) {
   debug('checking solution...');
@@ -61,7 +61,7 @@ exercise = cmdargscheck(exercise, function(args, callback) {
   debug('cmd line argument:');
   debug(args[0]);
 
-  if (args[0] >>> 0 === 9) {
+  if (args[0] >>> 0 === 4242) {
     return process.nextTick(function() {
       callback(null, true);
     });


### PR DESCRIPTION
These commits fix the following:

* In the "Print all objects with a given type exercise", the solution check looks for `bar = 9` which is incorrect and should be `bar = 4242` as specified in the [solution/question generation script] (https://github.com/joyent/node-debug-school/blob/master/exercises/print_all_objects_with_a_given_type/node-script-that-aborts.js#L23).

* When an incorrect value is given to the "Print all objects with a given type exercise" solution checker, it asks for the max-value instead of the min-value.

Additionally some clarity has been added to the description and output of the "Generate a core dump when app crashes" exercise. I found it somewhat easy to miss the prescribed output of the sample Node.js app.